### PR TITLE
Add llamacpp provider and integration test

### DIFF
--- a/.cursor/rules.md
+++ b/.cursor/rules.md
@@ -18,7 +18,20 @@ Supported providers in `cogents.common.llm`:
 - `ollama` - Local Ollama instances  
 - `llamacpp` - Local inference with llama-cpp-python (requires LLAMACPP_MODEL_PATH)
 
-## Python Command Execution
+## Development Workflow
+
+### After Each Implementation
+1. **Run unit tests**: `make test-unit` to ensure tests pass
+2. **Format code**: `make format` to apply consistent formatting
+3. **Check quality**: `make quality` for comprehensive code quality checks
+
+### Quick Development Checks
+- `make dev-check` - Quality + unit tests (fast feedback)
+- `make full-check` - All checks + tests + build (comprehensive)
+- `make ci-test` - CI test suite
+- `make ci-quality` - CI quality checks
+
+### Python Command Execution
 
 - **Always use `poetry run` for Python commands in development**
   - Use `poetry run python script.py` instead of `python script.py`
@@ -87,9 +100,20 @@ For llamacpp provider, you can set:
 
 - Integration tests are in `tests/integration/`
 - Unit tests are in `tests/unit/`
-- Use `poetry run pytest tests/` to run all tests
-- Use `poetry run pytest -m integration` for integration tests only
-- Use `poetry run pytest -m "not slow"` to skip slow tests
+- Use `make test-unit` to run unit tests
+- Use `make test-integration` to run integration tests
+- Use `make test` to run all tests
+- Use `poetry run pytest tests/` to run all tests (manual)
+- Use `poetry run pytest -m integration` for integration tests only (manual)
+- Use `poetry run pytest -m "not slow"` to skip slow tests (manual)
+
+## Code Quality
+
+- Use `make format` to format code (black, isort, autoflake)
+- Use `make format-check` to check formatting without changes
+- Use `make lint` to run linting (flake8, mypy)
+- Use `make quality` to run all quality checks
+- Use `make autofix` to auto-fix code quality issues
 
 ## Rationale
 

--- a/.cursor/rules.md
+++ b/.cursor/rules.md
@@ -1,5 +1,23 @@
 # Cursor AI Development Rules
 
+## Project Overview
+
+Cogents is a collection of essential building blocks for constructing sophisticated multi-agent systems.
+
+### Key Modules
+- `cogents.common.llm` - LLM provider abstractions with support for OpenAI, OpenRouter, Ollama, and LlamaCpp
+- `cogents.agents` - Various agent implementations
+- `cogents.memory` - Memory management for agents
+- `cogents.sensory` - Sensory processing capabilities
+- `cogents.toolify` - Tool integration framework
+
+### LLM Providers
+Supported providers in `cogents.common.llm`:
+- `openai` - OpenAI API compatible services
+- `openrouter` - OpenRouter API
+- `ollama` - Local Ollama instances  
+- `llamacpp` - Local inference with llama-cpp-python (requires LLAMACPP_MODEL_PATH)
+
 ## Python Command Execution
 
 - **Always use `poetry run` for Python commands in development**
@@ -21,6 +39,52 @@ python examples/tools/validate_optimization.py
 pytest tests/
 python -m cogents.example
 ```
+
+## LLM Usage Examples
+
+```python
+from cogents.common.llm import get_llm_client
+
+# OpenAI/OpenRouter providers
+client = get_llm_client(provider="openai", api_key="sk-...")
+client = get_llm_client(provider="openrouter", api_key="sk-...")
+
+# Local providers
+client = get_llm_client(provider="ollama", base_url="http://localhost:11434")
+client = get_llm_client(provider="llamacpp", model_path="/path/to/model.gguf")
+
+# LlamaCpp with custom settings
+client = get_llm_client(
+    provider="llamacpp", 
+    model_path="/path/to/model.gguf",
+    n_ctx=4096,              # Context window size
+    n_gpu_layers=32,         # GPU layers (-1 for all)
+    instructor=True          # Enable structured output
+)
+
+# Basic chat
+response = client.chat_completion([
+    {"role": "user", "content": "Hello!"}
+])
+
+# Structured output (requires instructor=True)
+client = get_llm_client(provider="openai", instructor=True)
+result = client.structured_completion(messages, MyPydanticModel)
+```
+
+### Environment Variables
+
+For llamacpp provider, you can set:
+- `LLAMACPP_MODEL_PATH` - Path to your GGUF model file
+- `LLAMACPP_CHAT_MODEL` - Model name for logging (optional)
+
+## Testing
+
+- Integration tests are in `tests/integration/`
+- Unit tests are in `tests/unit/`
+- Use `poetry run pytest tests/` to run all tests
+- Use `poetry run pytest -m integration` for integration tests only
+- Use `poetry run pytest -m "not slow"` to skip slow tests
 
 ## Rationale
 

--- a/.cursor/rules.md
+++ b/.cursor/rules.md
@@ -67,6 +67,11 @@ response = client.chat_completion([
     {"role": "user", "content": "Hello!"}
 ])
 
+# Alternative: using completion alias
+response = client.completion([
+    {"role": "user", "content": "Hello!"}
+])
+
 # Structured output (requires instructor=True)
 client = get_llm_client(provider="openai", instructor=True)
 result = client.structured_completion(messages, MyPydanticModel)

--- a/cogents/common/llm/__init__.py
+++ b/cogents/common/llm/__init__.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 from .base import BaseLLMClient
+from .llamacpp import LLMClient as LlamaCppLLMClient
 from .ollama import LLMClient as OllamaLLMClient
 from .openai import LLMClient as OpenAILLMClient
 from .openrouter import LLMClient as OpenRouterLLMClient
@@ -8,6 +9,7 @@ from .token_tracker import TokenUsage, TokenUsageTracker, get_token_tracker, rec
 
 __all__ = [
     "BaseLLMClient",
+    "LlamaCppLLMClient",
     "OpenRouterLLMClient",
     "OllamaLLMClient",
     "OpenAILLMClient",
@@ -37,7 +39,7 @@ def get_llm_client(
     Get an LLM client instance based on the specified provider.
 
     Args:
-        provider: LLM provider to use ("openrouter", "openai", "ollama")
+        provider: LLM provider to use ("openrouter", "openai", "ollama", "llamacpp")
         base_url: Base URL for API (used by openai provider)
         api_key: API key for authentication (used by openai and openrouter providers)
         instructor: Whether to enable instructor for structured output

--- a/cogents/common/llm/__init__.py
+++ b/cogents/common/llm/__init__.py
@@ -40,12 +40,14 @@ def get_llm_client(
 
     Args:
         provider: LLM provider to use ("openrouter", "openai", "ollama", "llamacpp")
-        base_url: Base URL for API (used by openai provider)
+        base_url: Base URL for API (used by openai and ollama providers)
         api_key: API key for authentication (used by openai and openrouter providers)
         instructor: Whether to enable instructor for structured output
         chat_model: Model to use for chat completions
         vision_model: Model to use for vision tasks
-        **kwargs: Additional provider-specific arguments
+        **kwargs: Additional provider-specific arguments:
+            - llamacpp: model_path, n_ctx, n_gpu_layers, etc.
+            - others: depends on provider
 
     Returns:
         LLMClient instance for the specified provider
@@ -82,8 +84,6 @@ def get_llm_client(
         )
     elif provider == "llamacpp":
         return LlamaCppLLMClient(
-            base_url=base_url,
-            api_key=api_key,
             instructor=instructor,
             chat_model=chat_model,
             vision_model=vision_model,
@@ -106,11 +106,13 @@ def get_llm_client_instructor(
 
     Args:
         provider: LLM provider to use ("openrouter", "openai", "ollama", "llamacpp")
-        base_url: Base URL for API (used by openai provider)
+        base_url: Base URL for API (used by openai and ollama providers)
         api_key: API key for authentication (used by openai and openrouter providers)
         chat_model: Model to use for chat completions
         vision_model: Model to use for vision tasks
-        **kwargs: Additional provider-specific arguments
+        **kwargs: Additional provider-specific arguments:
+            - llamacpp: model_path, n_ctx, n_gpu_layers, etc.
+            - others: depends on provider
 
     Returns:
         LLMClient instance with instructor enabled for the specified provider

--- a/cogents/common/llm/__init__.py
+++ b/cogents/common/llm/__init__.py
@@ -80,8 +80,17 @@ def get_llm_client(
             vision_model=vision_model,
             **kwargs,
         )
+    elif provider == "llamacpp":
+        return LlamaCppLLMClient(
+            base_url=base_url,
+            api_key=api_key,
+            instructor=instructor,
+            chat_model=chat_model,
+            vision_model=vision_model,
+            **kwargs,
+        )
     else:
-        raise ValueError(f"Unsupported provider: {provider}. Supported providers: openrouter, openai, ollama")
+        raise ValueError(f"Unsupported provider: {provider}. Supported providers: openrouter, openai, ollama, llamacpp")
 
 
 def get_llm_client_instructor(
@@ -96,7 +105,7 @@ def get_llm_client_instructor(
     Get an LLM client instance with instructor support based on the specified provider.
 
     Args:
-        provider: LLM provider to use ("openrouter", "openai", "ollama")
+        provider: LLM provider to use ("openrouter", "openai", "ollama", "llamacpp")
         base_url: Base URL for API (used by openai provider)
         api_key: API key for authentication (used by openai and openrouter providers)
         chat_model: Model to use for chat completions

--- a/cogents/common/llm/base.py
+++ b/cogents/common/llm/base.py
@@ -39,6 +39,29 @@ class BaseLLMClient(ABC):
             Generated text response or streaming response
         """
 
+    def completion(
+        self,
+        messages: List[Dict[str, str]],
+        temperature: float = 0.7,
+        max_tokens: Optional[int] = None,
+        stream: bool = False,
+        **kwargs,
+    ) -> Union[str, Dict[str, Any]]:
+        """
+        Generate completion using the configured model (alias for chat_completion).
+
+        Args:
+            messages: List of message dictionaries with 'role' and 'content' keys
+            temperature: Sampling temperature (0.0 to 2.0)
+            max_tokens: Maximum tokens to generate
+            stream: Whether to stream the response
+            **kwargs: Additional arguments to pass to the model
+
+        Returns:
+            Generated text response or streaming response
+        """
+        return self.chat_completion(messages, temperature, max_tokens, stream, **kwargs)
+
     @abstractmethod
     def structured_completion(
         self,

--- a/cogents/common/llm/llamacpp.py
+++ b/cogents/common/llm/llamacpp.py
@@ -23,8 +23,6 @@ class LLMClient(BaseLLMClient):
     def __init__(
         self,
         model_path: Optional[str] = None,
-        base_url: Optional[str] = None,
-        api_key: Optional[str] = None,
         instructor: bool = False,
         chat_model: Optional[str] = None,
         vision_model: Optional[str] = None,
@@ -37,8 +35,6 @@ class LLMClient(BaseLLMClient):
 
         Args:
             model_path: Path to the GGUF model file
-            base_url: Not used for llamacpp (kept for compatibility)
-            api_key: Not used for llamacpp (kept for compatibility)
             instructor: Whether to enable instructor for structured output
             chat_model: Model name (used for logging, defaults to model filename)
             vision_model: Vision model name (llamacpp doesn't support vision yet)

--- a/cogents/common/llm/llamacpp.py
+++ b/cogents/common/llm/llamacpp.py
@@ -1,0 +1,320 @@
+import base64
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Type, TypeVar, Union
+
+from llama_cpp import Llama
+from pydantic import BaseModel
+
+from cogents.common.langsmith import configure_langsmith, is_langsmith_enabled
+from cogents.common.llm.base import BaseLLMClient
+from cogents.common.llm.token_tracker import estimate_token_usage, get_token_tracker
+from cogents.common.logging import get_logger
+
+T = TypeVar("T")
+
+logger = get_logger(__name__)
+
+
+class LLMClient(BaseLLMClient):
+    """Client for interacting with local LLMs using llama-cpp-python."""
+
+    def __init__(
+        self,
+        model_path: Optional[str] = None,
+        base_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        instructor: bool = False,
+        chat_model: Optional[str] = None,
+        vision_model: Optional[str] = None,
+        n_ctx: int = 2048,
+        n_gpu_layers: int = -1,
+        **kwargs,
+    ):
+        """
+        Initialize the LLM client.
+
+        Args:
+            model_path: Path to the GGUF model file
+            base_url: Not used for llamacpp (kept for compatibility)
+            api_key: Not used for llamacpp (kept for compatibility)
+            instructor: Whether to enable instructor for structured output
+            chat_model: Model name (used for logging, defaults to model filename)
+            vision_model: Vision model name (llamacpp doesn't support vision yet)
+            n_ctx: Context window size
+            n_gpu_layers: Number of layers to offload to GPU (-1 for all)
+            **kwargs: Additional arguments to pass to Llama constructor
+        """
+        # Configure LangSmith tracing for observability
+        configure_langsmith()
+        self._langsmith_provider = "llamacpp"
+
+        # Get model path from parameter or environment
+        self.model_path = model_path or os.getenv("LLAMACPP_MODEL_PATH")
+        if not self.model_path:
+            raise ValueError(
+                "Model path is required. Provide model_path parameter or set LLAMACPP_MODEL_PATH environment variable."
+            )
+
+        if not os.path.exists(self.model_path):
+            raise FileNotFoundError(f"Model file not found: {self.model_path}")
+
+        # Initialize Llama model
+        llama_kwargs = {
+            "model_path": self.model_path,
+            "n_ctx": n_ctx,
+            "n_gpu_layers": n_gpu_layers,
+            "verbose": kwargs.get("verbose", False),
+            **kwargs,
+        }
+
+        try:
+            self.llama = Llama(**llama_kwargs)
+        except Exception as e:
+            logger.error(f"Failed to load model from {self.model_path}: {e}")
+            raise
+
+        # Model configurations
+        model_filename = Path(self.model_path).stem
+        self.chat_model = chat_model or os.getenv("LLAMACPP_CHAT_MODEL", model_filename)
+        self.vision_model = vision_model or os.getenv("LLAMACPP_VISION_MODEL", model_filename)
+
+        # Set instructor flag
+        self.instructor_enabled = instructor
+
+        logger.info(f"Initialized LlamaCpp client with model: {self.model_path}")
+
+    def chat_completion(
+        self,
+        messages: List[Dict[str, str]],
+        temperature: float = 0.7,
+        max_tokens: Optional[int] = None,
+        stream: bool = False,
+        **kwargs,
+    ) -> Union[str, Dict[str, Any]]:
+        """
+        Generate chat completion using the loaded model.
+
+        Args:
+            messages: List of message dictionaries with 'role' and 'content' keys
+            temperature: Sampling temperature (0.0 to 2.0)
+            max_tokens: Maximum tokens to generate
+            stream: Whether to stream the response (not supported in llamacpp)
+            **kwargs: Additional arguments
+
+        Returns:
+            Generated text response
+        """
+        if stream:
+            logger.warning("Streaming is not supported in llamacpp provider, falling back to non-streaming")
+
+        try:
+            # Convert messages to prompt format
+            prompt = self._format_messages_as_prompt(messages)
+
+            # Set default max_tokens if not provided
+            if max_tokens is None:
+                max_tokens = kwargs.get("max_tokens", 512)
+
+            # Generate response
+            response = self.llama(
+                prompt,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                echo=False,
+                **kwargs,
+            )
+
+            # Extract the generated text
+            output_text = response["choices"][0]["text"]
+
+            # Log token usage
+            self._log_token_usage(prompt, output_text, "completion")
+
+            return output_text.strip()
+
+        except Exception as e:
+            logger.error(f"Error in chat completion: {e}")
+            raise
+
+    def structured_completion(
+        self,
+        messages: List[Dict[str, str]],
+        response_model: Type[T],
+        temperature: float = 0.7,
+        max_tokens: Optional[int] = None,
+        attempts: int = 2,
+        backoff: float = 0.5,
+        **kwargs,
+    ) -> T:
+        """
+        Generate structured completion by prompting for JSON output.
+
+        Args:
+            messages: List of message dictionaries with 'role' and 'content' keys
+            response_model: Pydantic model class for structured output
+            temperature: Sampling temperature (0.0 to 2.0)
+            max_tokens: Maximum tokens to generate
+            attempts: Number of attempts to make
+            backoff: Backoff factor for exponential backoff
+            **kwargs: Additional arguments
+
+        Returns:
+            Structured response as the specified model type
+        """
+        if not self.instructor_enabled:
+            raise ValueError("Instructor is not enabled. Initialize LLMClient with instructor=True")
+
+        # Add JSON schema instruction to the last message
+        schema = response_model.model_json_schema()
+        json_instruction = f"\n\nPlease respond with a valid JSON object that matches this schema:\n{json.dumps(schema, indent=2)}\n\nRespond with only the JSON object, no additional text."
+
+        # Modify the last message to include JSON instruction
+        modified_messages = messages.copy()
+        if modified_messages:
+            modified_messages[-1]["content"] += json_instruction
+        else:
+            modified_messages = [{"role": "user", "content": json_instruction}]
+
+        import time
+
+        last_err = None
+        for i in range(attempts):
+            try:
+                # Get raw text response
+                raw_response = self.chat_completion(
+                    modified_messages, temperature=temperature, max_tokens=max_tokens, **kwargs
+                )
+
+                # Try to parse as JSON
+                try:
+                    # Clean the response (remove any markdown formatting)
+                    clean_response = raw_response.strip()
+                    if clean_response.startswith("```json"):
+                        clean_response = clean_response[7:]
+                    if clean_response.endswith("```"):
+                        clean_response = clean_response[:-3]
+                    clean_response = clean_response.strip()
+
+                    # Parse JSON
+                    parsed_json = json.loads(clean_response)
+                    result = response_model(**parsed_json)
+
+                    # Log token usage for structured completion
+                    prompt_text = "\n".join([msg.get("content", "") for msg in modified_messages])
+                    self._log_token_usage(prompt_text, str(result), "structured")
+
+                    return result
+
+                except (json.JSONDecodeError, ValueError) as e:
+                    logger.warning(f"Failed to parse JSON response (attempt {i+1}): {e}")
+                    last_err = e
+                    if i < attempts - 1:
+                        time.sleep(backoff * (2**i))
+                        continue
+                    else:
+                        raise ValueError(f"Failed to get valid JSON after {attempts} attempts: {last_err}")
+
+            except Exception as e:
+                logger.error(f"Error in structured completion attempt {i+1}: {e}")
+                last_err = e
+                if i < attempts - 1:
+                    time.sleep(backoff * (2**i))
+                else:
+                    raise
+
+        raise ValueError(f"Failed to complete structured generation after {attempts} attempts: {last_err}")
+
+    def understand_image(
+        self,
+        image_path: Union[str, Path],
+        prompt: str,
+        temperature: float = 0.7,
+        max_tokens: Optional[int] = None,
+        **kwargs,
+    ) -> str:
+        """
+        Analyze an image (not supported by llamacpp).
+
+        Args:
+            image_path: Path to the image file
+            prompt: Text prompt describing what to analyze in the image
+            temperature: Sampling temperature
+            max_tokens: Maximum tokens to generate
+            **kwargs: Additional arguments
+
+        Returns:
+            Analysis of the image
+
+        Raises:
+            NotImplementedError: Vision capabilities are not supported by llamacpp
+        """
+        raise NotImplementedError("Vision capabilities are not supported by the llamacpp provider")
+
+    def understand_image_from_url(
+        self,
+        image_url: str,
+        prompt: str,
+        temperature: float = 0.7,
+        max_tokens: Optional[int] = None,
+        **kwargs,
+    ) -> str:
+        """
+        Analyze an image from URL (not supported by llamacpp).
+
+        Args:
+            image_url: URL of the image
+            prompt: Text prompt describing what to analyze in the image
+            temperature: Sampling temperature
+            max_tokens: Maximum tokens to generate
+            **kwargs: Additional arguments
+
+        Returns:
+            Analysis of the image
+
+        Raises:
+            NotImplementedError: Vision capabilities are not supported by llamacpp
+        """
+        raise NotImplementedError("Vision capabilities are not supported by the llamacpp provider")
+
+    def _format_messages_as_prompt(self, messages: List[Dict[str, str]]) -> str:
+        """
+        Convert OpenAI-style messages to a single prompt string.
+
+        Args:
+            messages: List of message dictionaries
+
+        Returns:
+            Formatted prompt string
+        """
+        prompt_parts = []
+        for message in messages:
+            role = message.get("role", "user")
+            content = message.get("content", "")
+
+            if role == "system":
+                prompt_parts.append(f"System: {content}")
+            elif role == "user":
+                prompt_parts.append(f"User: {content}")
+            elif role == "assistant":
+                prompt_parts.append(f"Assistant: {content}")
+            else:
+                prompt_parts.append(f"{role}: {content}")
+
+        prompt_parts.append("Assistant:")
+        return "\n\n".join(prompt_parts)
+
+    def _log_token_usage(self, prompt: str, completion: str, call_type: str = "completion"):
+        """Estimate and record token usage."""
+        try:
+            usage = estimate_token_usage(prompt, completion, self.chat_model, call_type)
+            if usage:
+                get_token_tracker().record_usage(usage)
+                logger.debug(
+                    f"Token usage (estimated) - Prompt: {usage.prompt_tokens}, "
+                    f"Completion: {usage.completion_tokens}, "
+                    f"Total: {usage.total_tokens} (model: {usage.model_name})"
+                )
+        except Exception as e:
+            logger.debug(f"Could not estimate token usage: {e}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,8 @@ langchain-core = "^0.3.72"
 langchain-text-splitters = "^0.3.0"
 langchain-tavily = "^0.2.11"
 langchain-ollama = "^0.2.0"
+# Local LLM support
+llama-cpp-python = "^0.2.87"
 # LangGraph for workflow orchestration
 langgraph = "^0.5.4"
 # LangSmith for observability

--- a/tests/integration/test_llm_integration.py
+++ b/tests/integration/test_llm_integration.py
@@ -47,6 +47,22 @@ class TestLLMIntegration:
         assert len(response) > 0
         assert "Tokyo" in response or "japan" in response.lower()
 
+    def test_completion_alias(self):
+        """Test that completion method works as alias for chat_completion."""
+        messages = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Say 'test completed' exactly."},
+        ]
+
+        # Test completion method (alias)
+        response = self.client.completion(messages, temperature=0.1)
+
+        # Assertions
+        assert response is not None
+        assert isinstance(response, str)
+        assert len(response) > 0
+        assert "test completed" in response.lower()
+
     def test_chat_completion_convenience_function(self):
         """Test the convenience chat_completion function."""
         messages = [{"role": "user", "content": "What's the capital of France?"}]
@@ -405,6 +421,21 @@ class TestLlamaCppIntegration:
         assert isinstance(response, str)
         assert len(response) > 0
         assert "4" in response
+
+    def test_completion_alias(self):
+        """Test that completion method works as alias for chat_completion."""
+        messages = [
+            {"role": "system", "content": "You are a helpful assistant. Be concise."},
+            {"role": "user", "content": "What is 3+3? Answer with just the number."},
+        ]
+
+        response = self.client.completion(messages, temperature=0.1, max_tokens=10)
+
+        # Assertions
+        assert response is not None
+        assert isinstance(response, str)
+        assert len(response) > 0
+        assert "6" in response
 
     def test_chat_completion_with_conversation(self):
         """Test chat completion with conversation history."""

--- a/tests/integration/test_llm_integration.py
+++ b/tests/integration/test_llm_integration.py
@@ -371,3 +371,118 @@ class TestTokenUsageIntegration:
         # Should be roughly proportional to text length
         assert usage.prompt_tokens > 5  # Should be more than 5 tokens for that text
         assert usage.completion_tokens > 5
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+class TestLlamaCppIntegration:
+    """Integration tests for LlamaCpp LLM functionality."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Setup test environment."""
+        # Check if model path is available
+        model_path = os.getenv("LLAMACPP_MODEL_PATH")
+        if not model_path:
+            pytest.skip("LLAMACPP_MODEL_PATH not set in environment")
+        
+        if not os.path.exists(model_path):
+            pytest.skip(f"Model file not found at {model_path}")
+
+        self.client = get_llm_client(provider="llamacpp", model_path=model_path)
+
+    def test_chat_completion_basic(self):
+        """Test basic chat completion with llamacpp."""
+        messages = [
+            {"role": "system", "content": "You are a helpful assistant. Be concise."},
+            {"role": "user", "content": "What is 2+2? Answer with just the number."},
+        ]
+
+        response = self.client.chat_completion(messages, temperature=0.1, max_tokens=10)
+
+        # Assertions
+        assert response is not None
+        assert isinstance(response, str)
+        assert len(response) > 0
+        assert "4" in response
+
+    def test_chat_completion_with_conversation(self):
+        """Test chat completion with conversation history."""
+        messages = [
+            {"role": "system", "content": "You are a helpful math tutor."},
+            {"role": "user", "content": "What is 5 * 3?"},
+            {"role": "assistant", "content": "5 * 3 = 15"},
+            {"role": "user", "content": "What about 15 + 7?"},
+        ]
+
+        response = self.client.chat_completion(messages, temperature=0.1, max_tokens=20)
+
+        # Assertions
+        assert response is not None
+        assert isinstance(response, str)
+        assert len(response) > 0
+
+    def test_structured_completion(self):
+        """Test structured completion with llamacpp."""
+        from pydantic import BaseModel, Field
+
+        class MathResult(BaseModel):
+            problem: str = Field(description="The math problem")
+            answer: int = Field(description="The numerical answer")
+            explanation: str = Field(description="Brief explanation")
+
+        # Create client with instructor enabled
+        model_path = os.getenv("LLAMACPP_MODEL_PATH")
+        client = get_llm_client(provider="llamacpp", model_path=model_path, instructor=True)
+
+        messages = [
+            {
+                "role": "user",
+                "content": "Solve this math problem: What is 7 + 5? Provide a structured response."
+            }
+        ]
+
+        result = client.structured_completion(
+            messages, 
+            MathResult,
+            temperature=0.1, 
+            max_tokens=200,
+            attempts=3
+        )
+
+        # Assertions
+        assert isinstance(result, MathResult)
+        assert result.answer == 12
+        assert "7" in result.problem and "5" in result.problem
+        assert len(result.explanation) > 0
+
+    def test_vision_not_supported(self):
+        """Test that vision methods raise NotImplementedError."""
+        with pytest.raises(NotImplementedError, match="Vision capabilities are not supported"):
+            self.client.understand_image("/path/to/image.jpg", "What's in this image?")
+
+        with pytest.raises(NotImplementedError, match="Vision capabilities are not supported"):
+            self.client.understand_image_from_url("http://example.com/image.jpg", "What's in this image?")
+
+    def test_token_tracking(self):
+        """Test that token usage is tracked for llamacpp calls."""
+        from cogents.common.llm.token_tracker import get_token_tracker
+
+        # Reset tracker
+        tracker = get_token_tracker()
+        tracker.reset()
+
+        messages = [
+            {"role": "user", "content": "Say hello"},
+        ]
+
+        response = self.client.chat_completion(messages, temperature=0.1, max_tokens=10)
+
+        # Should have some token usage recorded (estimated)
+        assert tracker.get_total_tokens() > 0
+        assert tracker.call_count > 0
+
+        # Get latest usage
+        latest_usage = tracker.usage_history[-1]
+        assert latest_usage.estimated == True  # Should be estimated for llamacpp
+        assert latest_usage.call_type == "completion"


### PR DESCRIPTION
Add `llamacpp` provider to `common.llm` module to enable local LLM inference via `llama-cpp-python`.

---
<a href="https://cursor.com/background-agent?bcId=bc-c50e49d2-85f2-46c3-843e-43554a70a33a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c50e49d2-85f2-46c3-843e-43554a70a33a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

